### PR TITLE
DockerFile に Linter 通したり、ちょっと見直し中

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -66,7 +66,7 @@ RUN apt-get update \
   && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 WORKDIR "/${USER}"
-RUN rm --recursive "${INSTALL_DIR}"
+RUN rm --recursive "${INSTALL_TL_URL}"
 
 USER ${USER}
 RUN fc-cache -fv

--- a/Dockerfile
+++ b/Dockerfile
@@ -66,7 +66,7 @@ RUN apt-get update \
   && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 WORKDIR "/${USER}"
-RUN rm --recursive "${INSTALL_TL_URL}"
+RUN rm --recursive "${INSTALL_TL_DIR}"
 
 USER ${USER}
 RUN fc-cache -fv

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,12 +6,29 @@ FROM --platform=$TARGETPLATFORM debian:stable
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM
 
-MAINTAINER a-yasui
-
 ENV PATH=/usr/local/texlive/2022/bin/x86_64-linux:/usr/local/texlive/2023/bin/x86_64-linux:/usr/local/texlive/2022/bin/aarch64-linux:/usr/local/texlive/2023/bin/aarch64-linux:$PATH
 ENV LANG=C.UTF-8
 
-WORKDIR /workdir
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+#
+# Install And Build The TexLive
+ARG INSTALL_TL_DIR="/install"
+ARG INSTALL_TL_URL="https://mirror.ctan.org/systems/texlive/tlnet/install-tl-unx.tar.gz"
+ARG INSTALL_TL_REPOSITORY="https://mirror.ctan.org/systems/texlive/tlnet/"
+ARG TEX_PROFILE="${INSTALL_TL_DIR}/texlive.profile"
+
+LABEL maintainer="a.yasui@gmail.com" \
+      org.opencontainers.image.title="TexliveJaAdditionFonts" \
+      org.opencontainers.image.description="LuaLaTeX Live image for Japanese based on debian." \
+      org.opencontainers.image.version="latest" \
+      org.opencontainers.image.source="https://github.com/a-yasui/docker-texlive-ja-addition-fonts" \
+      org.opencontainers.image.licenses="MIT"
+
+ARG USER="tex"
+RUN useradd --create-home ${USER} && mkdir "${INSTALL_TL_DIR}"
+
+WORKDIR $INSTALL_TL_DIR
 
 ## If Stable Release: Maybe, release date will be */04/20 cycle.
 ### install-tl-unx.tar.gz : https://ftp.math.utah.edu/pub/tex/historic/systems/texlive/2021/tlnet-final/install-tl-unx.tar.gz
@@ -23,42 +40,43 @@ WORKDIR /workdir
 
 COPY mkcompile.sh /tmp/mkcompile.sh
 RUN chmod +x /tmp/mkcompile.sh \
-  && mkdir /tmp/install-tl-unx \
-  && /tmp/mkcompile.sh $TARGETPLATFORM \
+  && /tmp/mkcompile.sh "${TARGETPLATFORM}" "${TEX_PROFILE}" \
   && rm /tmp/mkcompile.sh
 
-RUN apt update \
-  && apt install -y perl wget xz-utils tar fontconfig libfreetype6 unzip \
-  && apt clean -y \
-  && wget -qO - https://mirror.ctan.org/systems/texlive/tlnet/install-tl-unx.tar.gz | \
-    tar -xz -C /tmp/install-tl-unx --strip-components=1 \
-  && /tmp/install-tl-unx/install-tl \
-      --no-gui \
-      --profile=/tmp/install-tl-unx/texlive.profile \
-      --repository https://mirror.ctan.org/systems/texlive/tlnet/ \
-  && tlmgr install \
-      collection-basic collection-latex \
-      collection-latexrecommended collection-latexextra \
-      collection-fontsrecommended collection-langjapanese \
-      collection-luatex latexmk \
-  && rm -fr /tmp/install-tl-unx
 
 ## Install Fonts
+COPY Hack-v3.003-ttf.zip IPAexfont00401.zip install-tl.sh .
+RUN chmod +x install-tl.sh
 
-RUN apt install -y unzip
-COPY Hack-v3.003-ttf.zip .
-RUN unzip Hack-v3.003-ttf.zip \
-  && mkdir -p /usr/share/fonts \
-  && cp -R ttf /usr/share/fonts/Hackfont \
-  && rm -rf Hack-v3.003-ttf.zip ttf
+## Install texLive
+RUN apt-get update \
+  && apt-get upgrade -y \
+  && apt-get install --no-install-recommends -y ca-certificates perl curl wget xz-utils tar libfreetype6 unzip \
+  # DownLoad
+  && wget -qO - "${INSTALL_TL_URL}" | tar -xz -C ${INSTALL_TL_DIR} --strip-components=1 \
+  # Install
+  && /${INSTALL_TL_DIR}/install-tl.sh "${INSTALL_TL_DIR}" "${TEX_PROFILE}" "${INSTALL_TL_REPOSITORY}" \
+  # Install Fonts
+  && apt-get install --no-install-recommends -y unzip fontconfig \
+  && mkdir -p "/${USER}/.fonts" \
+  && unzip Hack-v3.003-ttf.zip && cp -R ttf "/${USER}/.fonts/Hackfont" && rm -rf Hack-v3.003-ttf.zip ttf \
+  && unzip IPAexfont00401.zip  && cp -R IPAexfont00401 "/${USER}/.fonts/IPA" && rm -rf IPAexfont00401.zip IPAexfont00401 \
 
-COPY IPAexfont00401.zip .
-RUN unzip IPAexfont00401.zip \
-  && cp -R IPAexfont00401 /usr/share/fonts/IPA \
-  && rm -rf IPAexfont00401.zip IPAexfont00401
+  # CleanUp
+  && apt-get clean && rm -rf /var/lib/apt/lists/*
 
-## Make Font Caches
-RUN fc-cache -fv && mktexlsr && luaotfload-tool -v -vvv -u
-RUN apt remove -y unzip && apt clean -y && rm -rf /var/lib/apt/lists/*
+WORKDIR "/${USER}"
+RUN rm --recursive "${INSTALL_DIR}"
+
+USER ${USER}
+RUN fc-cache -fv
+
+# Load font cache, has to be done on each compilation otherwise
+# ("luaotfload | db : Font names database not found, generating new one.").
+# If not found, e.g. TeXLive 2012 and earlier, simply skip it. Will return exit code
+# 0 and allow the build to continue.
+# Warning: This is USER-specific. If the current `USER` for which we run this is not
+# the container user, the font will be regenerated for that new user.
+RUN luaotfload-tool --update || echo "luaotfload-tool did not succeed, skipping."
 
 CMD ["sh"]

--- a/install-tl.sh
+++ b/install-tl.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+#
+# Customze from https://github.com/alexpovel/latex-extras-docker/blob/master/texlive.sh
+
+set -ueo pipefail;
+
+# do this file.
+# 1. run `install-tl`
+# 2. symlink all tex bin file to /usr/local/bin
+
+WORKDIR=${1:-'/install'}
+TEX_PROFILE="${2:-'/install/tex'}"
+TEX_REPOSITORY="${3:-'https://mirror.ctan.org/systems/texlive/tlnet/'}"
+
+SYMLINK_DESTINATION="/usr/local/bin"
+
+# From: https://stackoverflow.com/a/2990533/11477374
+echoerr() { echo "$@" 1>&2; }
+
+check_path() {
+    # The following test assumes the most basic program, `tex`, is present, see also
+    # https://www.tug.org/texlive/doc/texlive-en/texlive-en.html#x1-380003.5
+    echo "Checking PATH and installation..."
+    if tex --version
+    then
+        echo "PATH and installation seem OK, exiting with success."
+        exit 0
+    else
+        echoerr "PATH or installation unhealthy, further action required..."
+    fi
+}
+
+cd "${WORKDIR}";
+
+perl "${WORKDIR}/install-tl" --profile="${TEX_PROFILE}" --repository="${TEX_REPOSITORY}";
+
+# Symlink to 
+
+# `\d` class doesn't exist for basic `grep`, use `0-9`, which is much more
+# portable. Finding the initial dir is very fast, but looking through everything
+# else afterwards might take a while. Therefore, print and quit after first result.
+# Path example: `/usr/local/texlive/2018/bin/x86_64-linux`
+TEXLIVE_BIN_DIR=$(find / -type d -regextype grep -regex '.*/texlive/[0-9]\{4\}/bin/.*' -print -quit)
+
+# -z test: string zero length?
+if [ -z "$TEXLIVE_BIN_DIR" ]
+then
+    echoerr "Expected TeXLive installation dir not found and TeXLive installation did not modify PATH automatically."
+    echoerr "Exiting."
+    exit 1
+fi
+
+echo "Found TeXLive binaries at $TEXLIVE_BIN_DIR"
+echo "Trying native TeXLive symlinking using tlmgr..."
+
+# To my amazement, `tlmgr path add` can fail but still link successfully. So
+# check if PATH is OK despite that command failing.
+"$TEXLIVE_BIN_DIR"/tlmgr path add || \
+    echoerr "Command borked, checking if it worked regardless..."
+
+check_path || \
+	echoerr "Symlinking using tlmgr did not succeed, trying manual linking..."
+
+# "String contains", see: https://stackoverflow.com/a/229606/11477374
+if [[ ! ${PATH} == *${SYMLINK_DESTINATION}* ]]
+then
+    # Should never get here, but make sure.
+    echoerr "Symlink destination ${SYMLINK_DESTINATION} not in PATH (${PATH}), exiting."
+    exit 1
+fi
+
+echo "Symlinking TeXLive binaries in ${TEXLIVE_BIN_DIR}"
+echo "to a directory (${SYMLINK_DESTINATION}) found on PATH (${PATH})"
+
+# Notice the slash and wildcard.
+ln \
+    --symbolic \
+    --verbose \
+    --target-directory="$SYMLINK_DESTINATION" \
+    "$TEXLIVE_BIN_DIR"/*
+
+check_path
+

--- a/mkcompile.sh
+++ b/mkcompile.sh
@@ -77,7 +77,7 @@ collection-games 0
 collection-humanities 0
 collection-langarabic 0
 collection-langchinese 0
-collection-langcjk 1
+collection-langcjk 0
 collection-langcyrillic 0
 collection-langczechslovak 0
 collection-langfrench 0

--- a/mkcompile.sh
+++ b/mkcompile.sh
@@ -2,39 +2,118 @@
 
 set -eux;
 
-OUTPUT_FILE="/tmp/install-tl-unx/texlive.profile"
-DEFAULT_OPT="${1:-linux/arm64}"
+DEFAULT_OPT="${1:-'linux/arm64'}"
+OUTPUT_FILE="${2:-'/tmp/install-tl-unx/texlive.profile'}"
 
-if [ ! -d "/tmp/install-tl-unx/" ]; then
-	mkdir -p "/tmp/install-tl-unx";
-fi
-
+# See: https://www.tug.org/texlive/doc/install-tl.html#ENVIRONMENT-VARIABLES,
+# https://tex.stackexchange.com/a/470341/120853.
+# IMPORTANT: Put these into the actual designated container's user's home for full
+# write access. Otherwise, we run into all sorts of annoying errors, like
+# https://tex.stackexchange.com/q/571021/120853.
+# The user we run this as is specified in the Dockerfile and inserted into here.
+BINARYOPT=$(printf "%s\n" "binary_aarch64-linux 1" "binary_x86_64-darwin 0" "binary_x86_64-linux 0" "binary_win32 0")
 if [ "${DEFAULT_OPT}" = "linux/amd64" ]; then
-	printf "%s\n" \
-		"selected_scheme scheme-basic" \
-		"binary_aarch64-linux 0" \
-		"binary_x86_64-darwin 0" \
-		"binary_x86_64-linux 1" \
-		"binary_win32 0" \
-		"option_doc 0" \
-		"option_src 0" \
-		"option_autobackup 0" \
-		"option_desktop_integration 0" \
-		"option_file_assocs 0" \
-		> "${OUTPUT_FILE}";
-
-	exit 0;
+	BINARYOPT=$(printf "%s\n" "binary_aarch64-linux 0" "binary_x86_64-darwin 0" "binary_x86_64-linux 1" "binary_win32 0")
 fi
 
-printf "%s\n" \
-	"selected_scheme scheme-basic" \
-	"binary_aarch64-linux 1" \
-	"binary_x86_64-darwin 0" \
-	"binary_x86_64-linux 0" \
-	"binary_win32 0" \
-	"option_doc 0" \
-	"option_src 0" \
-	"option_autobackup 0" \
-	"option_desktop_integration 0" \
-	"option_file_assocs 0" \
-	> "${OUTPUT_FILE}";
+cat <<__EOL__ > "${OUTPUT_FILE}";
+#
+# Via: https://github.com/alexpovel/latex-extras-docker/blob/master/config/texlive.profile
+#
+selected_scheme scheme-custom
+
+TEXMFHOME /home/\${USER}/texmf
+TEXMFVAR /home/\${USER}/.texlive/texmf-var
+TEXMFCONFIG /home/\${USER}/.texlive/texmf-config
+${BINARYOPT}
+option_doc 0
+option_src 0
+option_autobackup 0
+option_desktop_integration 0
+option_file_assocs 0
+
+# Not required, left at default:
+# TEXDIR /usr/local/texlive/<version>
+# TEXMFSYSCONFIG /usr/local/texlive/<version>/texmf-config
+# TEXMFSYSVAR /usr/local/texlive/<version>/texmf-var
+# TEXMFLOCAL /usr/local/texlive/texmf-local
+#
+# -------------------------------------------------------------------------------
+# Collections of packages; for their contents, see
+# http://mirror.ctan.org/systems/texlive/tlnet/tlpkg/texlive.tlpdb
+# and search for 'name collection-<name>', e.g. 'name collection-basic'.
+# At the time of writing, the following encompasses all available collections.
+# Only the core ones with very few supported languages are enabled. For example,
+# just including 'collection-langjapanese' requires 800MB of space.
+# -------------------------------------------------------------------------------
+collection-basic 1
+collection-bibtexextra 1
+collection-binextra 1
+collection-fontsextra 1
+collection-fontsrecommended 1
+collection-fontutils 1
+collection-formatsextra 1
+collection-langenglish 1
+collection-langeuropean 1
+collection-langgerman 1
+collection-latex 1
+collection-latexextra 1
+collection-latexrecommended 1
+collection-luatex 1
+collection-mathscience 1
+collection-pictures 1
+collection-plaingeneric 1
+collection-publishers 1
+collection-xetex 1
+# -------------------------------------------------------------------------------
+# Enable the following disabled ones as needed. They are included here so
+# everyone can see what is available; as many as possible are disabled, since
+# image size matters. The default is aimed at documents in the sciences domain.
+# Therefore, everything else is disabled. This includes various languages, so
+# activate your missing language here!
+# -------------------------------------------------------------------------------
+collection-context 0
+collection-games 0
+collection-humanities 0
+collection-langarabic 0
+collection-langchinese 0
+collection-langcjk 1
+collection-langcyrillic 0
+collection-langczechslovak 0
+collection-langfrench 0
+collection-langgreek 0
+collection-langitalian 0
+collection-langjapanese 1
+collection-langkorean 0
+collection-langother 0
+collection-langpolish 0
+collection-langportuguese 0
+collection-langspanish 0
+collection-metapost 0
+collection-music 0
+collection-pstricks 0
+collection-texworks 0
+collection-wintools 0
+
+# At the same time, TeXLive 2020 does not seem to respect the set TEXDIR, breaking
+# installation. However, adjusting the path here automatically works.
+# Since older installations will simply ignore this setting, enable it for safety.
+instopt_adjustpath 1
+
+# Not Portable
+instopt_portable 0
+
+# Create font format files, otherwise they have to be created on the fly each
+# time.
+tlpdbopt_create_formats 1
+# None of the following is required; especially not documentation and source
+# files, which fill multiple GBs
+tlpdbopt_desktop_integration 0
+tlpdbopt_file_assocs 0
+tlpdbopt_generate_updmap 0
+tlpdbopt_install_docfiles 0
+tlpdbopt_install_srcfiles 0
+#
+# Execute postinstallation code for packages:
+tlpdbopt_post_code 1
+__EOL__


### PR DESCRIPTION
# すること

だいたいは https://github.com/alexpovel/latex-extras-docker/ の内容に近づける。

ただし、このリポジトリでしている日本語対応、x86_64, arm64 それぞれ別々のDockerImageを作成、をする感じ。

1. 今まで `/usr/local/texlive/~~` に通してたパスを `/usr/local/bin` だけにする。
2. DockerImage 内部のユーザを tex にする。

## 関連

- https://github.com/a-yasui/docker-texlive-ja-addition-fonts/issues/1